### PR TITLE
Move UsersController to Admin::UsersController

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,23 @@
+module Admin
+  class UsersController < ApplicationController
+    before_action :ensure_admin!
+    include Sufia::UsersControllerBehavior
+    layout 'admin'
+
+    def self.local_prefixes
+      ['users']
+    end
+
+    private
+
+      def ensure_admin!
+        # Even though the user can view this admin set, they may not be able to view
+        # it on the admin page.
+        authorize! :read, :admin_dashboard
+      end
+
+      def deny_access(_exception)
+        redirect_to main_app.root_url, alert: "You are not authorized to view this page"
+      end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,0 @@
-class UsersController < ApplicationController
-  include Sufia::UsersControllerBehavior
-  layout 'admin'
-end

--- a/app/views/sufia/admin/_sidebar.html.erb
+++ b/app/views/sufia/admin/_sidebar.html.erb
@@ -76,7 +76,7 @@
         <% end %>
 
         <% if can? :manage, User %>
-          <%= nav_link(sufia.profiles_path) do %>
+          <%= nav_link(main_app.admin_users_path) do %>
             <span class="fa fa-user"></span> <%= t('sufia.admin.sidebar.manage_users') %>
           <% end %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,10 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :admin do
+    resources :users, only: :index
+  end
+
   mount Peek::Railtie => '/peek'
   mount Riiif::Engine => '/images', as: 'riiif'
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Admin::UsersController do
+  context "with an admin user" do
+    before do
+      sign_in create(:admin)
+    end
+
+    describe "#index" do
+      it "uses the admin layout" do
+        get :index
+        expect(response).to render_template('layouts/admin')
+      end
+    end
+  end
+
+  context "with an anonymous user" do
+    describe "#index" do
+      it "is unauthorized" do
+        get :index
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because the public still uses the regular UsersController and they don't
want to use it with the admin layout.
Fixes #478