### PR TITLE
Require the correct MailboxController

### DIFF
--- a/app/controllers/hyrax/mailbox_controller.rb
+++ b/app/controllers/hyrax/mailbox_controller.rb
@@ -1,0 +1,7 @@
+require File.join(Hyrax::Engine.paths['app/controllers'].first, 'hyrax/mailbox_controller.rb')
+
+module Hyrax
+  class MailboxController
+    layout 'admin'
+  end
+end

--- a/app/controllers/mailbox_controller.rb
+++ b/app/controllers/mailbox_controller.rb
@@ -1,5 +1,0 @@
-require File.join(Hyrax::Engine.paths['app/controllers'].first, 'mailbox_controller.rb')
-
-class MailboxController
-  layout 'admin'
-end

--- a/spec/controllers/hyrax/mailbox_controller_spec.rb
+++ b/spec/controllers/hyrax/mailbox_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::MailboxController do
+  routes { Hyrax::Engine.routes }
+
+  before do
+    sign_in create(:user)
+  end
+
+  describe "#index" do
+    it 'uses the admin layout' do
+      get :index
+      expect(response).to render_template("admin")
+    end
+  end
+end


### PR DESCRIPTION
Previously it was using the non-namespaced controller, but Hyrax uses
the controller in its namespace.

Fixes #509