### PR TITLE
Provide iiif manifests for all work types

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,7 +11,7 @@ require: rubocop-rspec
 RSpec/SubjectStub:
   Exclude:
     - 'spec/models/solr_endpoint_spec.rb'
-      
+
 # Offense count: 10
 RSpec/LeadingSubject:
   Exclude:
@@ -20,7 +20,6 @@ RSpec/LeadingSubject:
     - 'spec/lib/active_job_tenant_spec.rb'
     - 'spec/lib/importer/factory/string_literal_processor_spec.rb'
     - 'spec/lib/stanford/importer/mods_parser_spec.rb'
-    - 'spec/presenters/hyrax/generic_work_show_presenter_spec.rb'
     - 'spec/services/create_account_spec.rb'
     - 'spec/services/iiif_thumbnail_path_service_spec.rb'
     - 'spec/services/solr_config_uploader_spec.rb'

--- a/app/controllers/concerns/hyku/iiif_manifest.rb
+++ b/app/controllers/concerns/hyku/iiif_manifest.rb
@@ -1,0 +1,26 @@
+module Hyku
+  # A controller mixin that provides a manifest action, which returns a
+  # IIIF manifest for the presentation API
+  module IIIFManifest
+    extend ActiveSupport::Concern
+
+    included do
+      self.show_presenter = Hyku::ManifestEnabledWorkShowPresenter
+
+      skip_load_and_authorize_resource only: :manifest
+    end
+
+    def manifest
+      headers['Access-Control-Allow-Origin'] = '*'
+      respond_to do |format|
+        format.json { render json: manifest_builder.to_h }
+      end
+    end
+
+    private
+
+      def manifest_builder
+        ::IIIFManifest::ManifestFactory.new(presenter)
+      end
+  end
+end

--- a/app/controllers/hyrax/generic_works_controller.rb
+++ b/app/controllers/hyrax/generic_works_controller.rb
@@ -1,4 +1,3 @@
-require 'iiif_manifest'
 module Hyrax
   class GenericWorksController < ApplicationController
     include Hyrax::CurationConcernController
@@ -6,21 +5,7 @@ module Hyrax
     include Hyrax::WorksControllerBehavior
 
     self.curation_concern_type = GenericWork
-    self.show_presenter = Hyrax::GenericWorkShowPresenter
 
-    skip_load_and_authorize_resource only: :manifest
-
-    def manifest
-      headers['Access-Control-Allow-Origin'] = '*'
-      respond_to do |format|
-        format.json { render json: manifest_builder.to_h }
-      end
-    end
-
-    private
-
-      def manifest_builder
-        IIIFManifest::ManifestFactory.new(presenter)
-      end
+    include Hyku::IIIFManifest
   end
 end

--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -1,6 +1,3 @@
-# Generated via
-#  `rails generate curation_concerns:work Image`
-
 module Hyrax
   class ImagesController < ApplicationController
     include Hyrax::CurationConcernController
@@ -8,5 +5,7 @@ module Hyrax
     include Hyrax::WorksControllerBehavior
 
     self.curation_concern_type = Image
+
+    include Hyku::IIIFManifest
   end
 end

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -1,5 +1,5 @@
-module Hyrax
-  class GenericWorkShowPresenter < Hyrax::WorkShowPresenter
+module Hyku
+  class ManifestEnabledWorkShowPresenter < Hyrax::WorkShowPresenter
     self.file_presenter_class = Hyku::FileSetPresenter
 
     def manifest_url

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::GenericWorksController do
     before do
       sign_in user
       allow(IIIFManifest::ManifestFactory).to receive(:new)
-        .with(Hyrax::GenericWorkShowPresenter)
+        .with(Hyku::ManifestEnabledWorkShowPresenter)
         .and_return(manifest_factory)
     end
 
@@ -31,7 +31,7 @@ RSpec.describe Hyrax::GenericWorksController do
     end
     subject { controller.send :presenter }
     it "initializes a presenter" do
-      expect(subject).to be_kind_of Hyrax::GenericWorkShowPresenter
+      expect(subject).to be_kind_of Hyku::ManifestEnabledWorkShowPresenter
       expect(subject.manifest_url).to eq "http://test.host/concern/generic_works/#{solr_document.id}/manifest"
     end
   end

--- a/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Hyrax::GenericWorkShowPresenter do
+RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
   let(:document) { { "has_model_ssim" => ['GenericWork'], 'id' => '99' } }
   let(:solr_document) { SolrDocument.new(document) }
   let(:request) { double(base_url: 'http://test.host') }
@@ -18,13 +18,15 @@ RSpec.describe Hyrax::GenericWorkShowPresenter do
   end
 
   describe "representative_presenter" do
-    let(:work) { FactoryGirl.create(:work_with_one_file) }
-    let(:document) { work.to_solr }
-    before do
-      work.representative_id = work.file_sets.first.id
-    end
     subject do
       presenter.representative_presenter
+    end
+
+    let(:work) { FactoryGirl.create(:work_with_one_file) }
+    let(:document) { work.to_solr }
+
+    before do
+      work.representative_id = work.file_sets.first.id
     end
     it "returns a presenter" do
       expect(subject).to be_kind_of Hyku::FileSetPresenter


### PR DESCRIPTION
Previously manifests were only created for GenericWorks (not for
Images).

Fixes #501