### PR TITLE
Ability#user_groups should include the admin group

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,11 +33,6 @@ class Ability
     end
   end
 
-  # Override admin? helper to use rolify roles
-  def admin?
-    current_user.has_role?(:admin, Site.instance)
-  end
-
   private
 
     def global_models

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,11 @@ class User < ActiveRecord::Base
     end
   end
 
+  def groups
+    return ['admin'] if has_role?(:admin, Site.instance)
+    []
+  end
+
   private
 
     def add_default_roles

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 require 'cancan/matchers'
 
 RSpec.describe Ability do
-  subject { described_class.new(user) }
+  subject { ability }
+  let(:ability) { described_class.new(user) }
 
   describe 'an anonymous user' do
     let(:user) { nil }
@@ -19,6 +20,14 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, :all) }
     it { is_expected.not_to be_able_to(:manage, Account) }
     it { is_expected.to be_able_to(:manage, Site) }
+
+    describe "#user_groups" do
+      subject { ability.user_groups }
+
+      it "has the admin group" do
+        expect(subject).to include 'admin'
+      end
+    end
   end
 
   describe 'a superadmin user' do


### PR DESCRIPTION
This allows the access controls to match objects that have the admin
group set. Ref #536

See
https://github.com/projecthydra-labs/hyrax/blob/1e504c200fd9c39120f514ac33cd42cd843de9fa/app/services/hyrax/admin_set_create_service.rb#L17

for an example of where it expects the admin to be a member of the admin
group.