### PR TITLE
Load workflows when rendering workflow roles UI.

### DIFF
--- a/app/presenters/hyku/menu_presenter.rb
+++ b/app/presenters/hyku/menu_presenter.rb
@@ -17,6 +17,12 @@ module Hyku
     end
 
     # Returns true if the current controller happens to be one of the controllers that deals
+    # with workflow.  This is used to keep the parent section on the sidebar open.
+    def workflows_section?
+      %w(admin workflow_roles).include?(controller_name)
+    end
+
+    # Returns true if the current controller happens to be one of the controllers that deals
     # with roles and permissions.  This is used to keep the parent section on the sidebar open.
     def roles_and_permissions_section?
       # we're using a case here because we need to differentiate UsersControllers

--- a/app/views/hyrax/admin/_sidebar.html.erb
+++ b/app/views/hyrax/admin/_sidebar.html.erb
@@ -67,6 +67,23 @@
       <span class="fa fa-sitemap"></span> <%= t('hyrax.admin.sidebar.admin_sets') %>
     <% end %>
 
+    <li>
+      <a role="button" class="collapsed collapse-toggle" data-toggle="collapse" href="#collapseWorkflows" aria-expanded="false" aria-controls="collapseWorkflows">
+        <span class="fa fa-code-fork"></span>
+        <span><%= t('hyrax.admin.sidebar.workflow') %></span>
+      </a>
+      <% workflows_class = 'collapse ' unless menu.workflows_section? %>
+      <ul class="<%= workflows_class %>nav nav-pills nav-stacked" id="collapseWorkflows">
+        <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
+          <span class="fa fa-users"></span> <%= t('hyrax.admin.sidebar.workflow_roles') %>
+        <% end %>
+
+        <%= menu.nav_link(hyrax.admin_workflows_path) do %>
+          <span class="fa fa-flag"></span> <%= t('hyrax.admin.sidebar.workflow_review') %>
+        <% end %>
+      </ul>
+    </li>
+
     <% if can?(:manage, Role) || can?(:manage, User) %>
     <li>
       <a role="button" class="collapsed collapse-toggle" data-toggle="collapse" href="#collapseRoles" aria-expanded="false" aria-controls="collapseRoles">

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -1,0 +1,12 @@
+# TODO: These changes should move into Hyrax
+Hyrax::Admin::WorkflowRolesController.class_eval do
+  layout 'admin'
+
+  before_action only: [:index] do
+    add_breadcrumb t(:'hyrax.controls.home'), root_path
+    add_breadcrumb t(:'hyrax.toolbar.admin.menu'), hyrax.admin_path
+    add_breadcrumb t(:'hyrax.admin.workflow_roles.header'), hyrax.admin_workflow_roles_path
+    # TODO: Find a better way to make sure workflows are loaded
+    Hyrax::Workflow::WorkflowImporter.load_workflows
+  end
+end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -6,5 +6,6 @@ en:
     account_name:       "Hydra in a Box Account Id"
     directory:
       suffix:           "@hydrainabox.org"
-    footer:
-      copyright_html: "<strong>Copyright &copy; 2016 Project Hydra</strong> Licensed under the Apache License, Version 2.0"
+    admin:
+      workflow_roles:
+        header: "Workflow Roles"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -6,3 +6,6 @@ es:
     account_name:       "Hydra-en-una-Caja Cuenta ID"
     directory:
       suffix:           "@hydrainabox.org"
+    admin:
+      workflow_roles:
+        header: "Funciones del Flujo de Trabajo"

--- a/config/workflows/mediated_deposit_workflow.json
+++ b/config/workflows/mediated_deposit_workflow.json
@@ -3,7 +3,7 @@
         {
             "name": "one_step_mediated_deposit",
             "label": "One-step mediated deposit workflow",
-            "description": "A single-step workflow for mediated deposit",
+            "description": "A single-step workflow for mediated deposit in which all deposits must be approved by a reviewer. Reviewer may also send deposits back to the depositor.",
             "actions": [
                 {
                     "name": "deposit",
@@ -15,9 +15,25 @@
                             "name": "Hyrax::Workflow::PendingReviewNotification",
                             "to": ["approving"]
                         }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::DeactivateObject"
                     ]
-                },
-                {
+                }, {
+                    "name": "request_changes",
+                    "from_states": [{"names": ["complete", "pending_review"], "roles": ["approving"]}],
+                    "transition_to": "changes_required",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::ChangesRequiredNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::DeactivateObject"
+                    ]
+                }, {
                     "name": "approve",
                     "from_states": [{"names": ["pending_review"], "roles": ["approving"]}],
                     "transition_to": "complete",
@@ -29,7 +45,18 @@
                         }
                     ],
                     "methods": [
-                        "CurationConcerns::Workflow::ActivateObject"
+                        "Hyrax::Workflow::ActivateObject"
+                    ]
+                }, {
+                    "name": "request_review",
+                    "from_states": [{"names": ["changes_required"], "roles": ["depositing"]}],
+                    "transition_to": "pending_review",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::PendingReviewNotification",
+                            "to": ["approving"]
+                        }
                     ]
                 }
             ]

--- a/spec/controllers/hyrax/admin/workflow_roles_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/workflow_roles_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe Hyrax::Admin::WorkflowRolesController, :no_clean do
+  routes { Hyrax::Engine.routes }
+
+  describe "#get overrides" do
+    before do
+      allow(controller).to receive(:authorize!).with(:read, :admin_dashboard).and_return(true)
+    end
+
+    it "loads workflows and renders with the admin layout" do
+      expect(Hyrax::Workflow::WorkflowImporter).to receive(:load_workflows).once
+      get :index
+      expect(response).to render_template(layout: 'admin')
+    end
+  end
+end

--- a/spec/presenters/hyku/menu_presenter_spec.rb
+++ b/spec/presenters/hyku/menu_presenter_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe Hyku::MenuPresenter do
     end
   end
 
+  describe "#workflows_section?" do
+    before do
+      allow(context).to receive(:controller_name).and_return(controller_name)
+      allow(context).to receive(:controller).and_return(controller)
+    end
+    subject { instance.workflows_section? }
+    context "for the WorkflowRolesController" do
+      let(:controller) { Hyrax::Admin::WorkflowRolesController.new }
+      it { is_expected.to be true }
+    end
+    context "for the Admin::UsersController" do
+      let(:controller) { Admin::UsersController.new }
+      it { is_expected.to be false }
+    end
+  end
+
   describe "#roles_and_permissions_section?" do
     before do
       allow(context).to receive(:controller_name).and_return(controller_name)


### PR DESCRIPTION
Refs #563

This is a temporary hack to automatically load workflows in the demo instance. It also:

* Overrides the WorkflowRolesController to specify the admin layout (workaround for projecthydra-labs/hyrax#67)
* Adds breadcrumbs to the WorkflowRolesController override (should also be done in Hyrax)
* Pulls in the workflow section to the admin sidebar from Hyrax (and tweaked to use the Hyku MenuPresenter)
* Adds I18n for the workflow roles header
* Updates the hyku mediated deposit json to pull in the latest from Hyrax