### PR TITLE
Remove duplicate "Featured Researcher" title

### DIFF
--- a/app/views/hyrax/homepage/_featured_researcher.html.erb
+++ b/app/views/hyrax/homepage/_featured_researcher.html.erb
@@ -1,3 +1,2 @@
-<h2>Featured Researcher</h2>
-<%= link_to 'View other featured researchers', hyrax.featured_researchers_path %>
+<%= link_to t('hyrax.homepage.featured_researcher.view_more'), hyrax.featured_researchers_path %>
 <%= displayable_content_block @featured_researcher %>


### PR DESCRIPTION
Removed "Featured Researcher" heading because the title is already either on the content
section or on the tab from the prior partial (in hyrax). 

Also changed to access the text from the hyrax yml file to enable appropriate language function for this content block.

This resolves issue https://github.com/projecthydra-labs/hyku/issues/555