### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/projecthydra-labs/hyrax.git
-  revision: 343f84a2e04ea7a12cd88344a0494b5234f20f72
+  revision: 0adee359fe946b5d2cc95c022279f01f38b92f1c
   specs:
     hyrax (0.0.1.alpha)
       active_attr (~> 0.9.0)
@@ -654,7 +654,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    secure_headers (3.5.1)
+    secure_headers (3.6.0)
       useragent
     select2-rails (3.5.10)
       thor (~> 0.14)
@@ -668,7 +668,7 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
-    simple_form (3.3.1)
+    simple_form (3.4.0)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
     simplecov (0.12.0)


### PR DESCRIPTION
Including simple_form, which removes ruby 2.4 deprecations