### PR TITLE
Fix Redis config when sentinels are not specified

### DIFF
--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -1,7 +1,9 @@
 config = YAML.load(ERB.new(IO.read(Rails.root + 'config' + 'redis.yml')).result)[Rails.env].with_indifferent_access
+sentinels = config[:sentinel] && config[:sentinel][:host] ? { sentinels: [config[:sentinel]] } : {}
+redis_config = config.except(:sentinel).merge(thread_safe: true).merge(sentinels)
 require 'redis'
 Redis.current = begin
-                  Redis.new(config.except(:sentinel).merge(thread_safe: true, sentinels: ([config[:sentinel]] if config[:sentinel] && config[:sentinel][:host])))
+                  Redis.new(redis_config)
                 rescue
                   nil
                 end


### PR DESCRIPTION
Previously the configuration hash included:
```ruby
 { sentinels: nil }
```

This caused an error with the redis client.

Now we no longer pass along `sentinels:` if it is not present in the
configuration file.

Fixes #466