### PR TITLE
Update dependencies including browse-everything

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/projecthydra-labs/hyrax.git
-  revision: 9be85435e8f9cb95037ba6f0b0c101253ded5f4b
+  revision: a5c9dc983aa19de2827ace53817e57e1f66685da
   specs:
     hyrax (0.0.1.alpha)
       active_attr (~> 0.9.0)
@@ -133,13 +133,13 @@ GEM
       execjs
     awesome_nested_set (3.1.1)
       activerecord (>= 4.0.0, < 5.1)
-    aws-sdk (2.6.44)
-      aws-sdk-resources (= 2.6.44)
-    aws-sdk-core (2.6.44)
+    aws-sdk (2.6.46)
+      aws-sdk-resources (= 2.6.46)
+    aws-sdk-core (2.6.46)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.44)
-      aws-sdk-core (= 2.6.44)
+    aws-sdk-resources (2.6.46)
+      aws-sdk-core (= 2.6.46)
     aws-sigv4 (1.0.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -168,7 +168,8 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     breadcrumbs_on_rails (3.0.1)
-    browse-everything (0.11.0)
+    browse-everything (0.11.1)
+      addressable (~> 2.5)
       aws-sdk
       bootstrap-sass
       dropbox-sdk (>= 1.6.2)
@@ -212,7 +213,7 @@ GEM
       activesupport (>= 3.0)
       deep_merge (~> 1.1.1)
     connection_pool (2.2.1)
-    coveralls (0.8.17)
+    coveralls (0.8.18)
       json (>= 1.8, < 3)
       simplecov (~> 0.12.0)
       term-ansicolor (~> 1.3)


### PR DESCRIPTION
BrowseEverything was previously causing a NameError to be raised in
background jobs. See
https://github.com/projecthydra/browse-everything/issues/146