### PR TITLE
Adding support for i18n-debug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
 
+  gem 'i18n-debug', require: false
   gem 'rspec'
   gem 'rspec-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,6 +384,8 @@ GEM
       hydra-pcdm (>= 0.9)
       om (~> 3.1)
     i18n (0.8.1)
+    i18n-debug (1.1.0)
+      i18n (< 1)
     ice_nine (0.11.2)
     iiif-presentation (0.1.0)
       activesupport (>= 3.2.18)
@@ -799,6 +801,7 @@ DEPENDENCIES
   fog-aws
   honeybadger (~> 2.0)
   hyrax!
+  i18n-debug
   iiif_manifest (~> 0.1.2)
   is_it_working
   jbuilder (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ DISABLE_REDIS_CLUSTER=true bundle exec rails server -b 0.0.0.0
 
 See the [Hyku Development Guide](https://github.com/projecthydra-labs/hyku/wiki/Hyku-Development-Guide) for how to run tests.
 
+### Working with Translations
+
+You can log all of the I18n lookups to the Rails logger by setting the I18N_DEBUG environment variable to true. This will add a lot of chatter to the Rails logger (but can be very helpful to zero in on what I18n key you should or could use).
+
+```console
+$ I18N_DEBUG=true bin/rails server
+```
+
 ### On AWS
 
 AWS CloudFormation templates for the Hyku stack are available in a separate repository:

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require 'i18n/debug' if ENV['I18N_DEBUG']
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'active_fedora/noid/rspec'
 require 'webmock/rspec'
+require 'i18n/debug' if ENV['I18N_DEBUG']
 
 RSpec.configure do |config|
   include ActiveFedora::Noid::RSpec


### PR DESCRIPTION
See https://github.com/fphilipe/i18n-debug. We may need to observe if
this adds any significant time to builds.

Below is example output that is written to
`./log/test.log`:

```console
[i18n-debug] en.simple_form.labels.file_set.files => nil
[i18n-debug] en.simple_form.labels.file_set.files => nil
[i18n-debug] en.simple_form.labels.defaults.files => "Upload a file"
[i18n-debug] en.simple_form.required.text => "required"
[i18n-debug] en.simple_form.required.mark => "*"
[i18n-debug] en.simple_form.required.html => "<span class=\"label label-info required-tag\">required</span>"
[i18n-debug] en.simple_form.hints.file_set.files => nil
[i18n-debug] en.simple_form.hints.file_set.files => nil
[i18n-debug] en.simple_form.hints.defaults.files => nil
[i18n-debug] en.simple_form.hints.defaults.files => nil
[i18n-debug] en.simple_form.hints.file_set.files => nil
[i18n-debug] en.simple_form.hints.file_set.files => nil
[i18n-debug] en.simple_form.hints.defaults.files => nil
[i18n-debug] en.simple_form.hints.defaults.files => nil
[i18n-debug] en.activemodel.models.file_set => nil
[i18n-debug] en.activemodel.models.active_fedora/base => nil
[i18n-debug] en.helpers.submit.file_set.update => nil
[i18n-debug] en.helpers.submit.update => "Save"
```

While the specs are running, I was running the following command to see
what translation keys was hit or missed:

```console
tail -f ./log/test.log
```

@projecthydra-labs/hyrax-code-reviewers 