### PR TITLE
Make only about_page tab active

### DIFF
--- a/app/views/content_blocks/_form.html.erb
+++ b/app/views/content_blocks/_form.html.erb
@@ -30,7 +30,7 @@
         <% end %>
       </div>
     </div>
-    <div id="marketing_text" class="tab-pane active">
+    <div id="marketing_text" class="tab-pane">
       <div class="panel panel-default labels">
         <%= simple_form_for @site, url: site_content_blocks_path do |f| %>
           <div class="panel-body">
@@ -46,7 +46,7 @@
         <% end %>
       </div>
     </div>
-    <div id="announcement_text" class="tab-pane active">
+    <div id="announcement_text" class="tab-pane">
       <div class="panel panel-default labels">
         <%= simple_form_for @site, url: site_content_blocks_path do |f| %>
           <div class="panel-body">
@@ -62,7 +62,7 @@
         <% end %>
       </div>
     </div>
-    <div id="featured_researcher" class="tab-pane active">
+    <div id="featured_researcher" class="tab-pane">
       <div class="panel panel-default labels">
         <%= simple_form_for @site, url: site_content_blocks_path do |f| %>
           <div class="panel-body">


### PR DESCRIPTION
Fixes https://github.com/projecthydra-labs/hyku/issues/574

Note: inactive tabs have a smaller text box area than the active tab (see images below comparing the active tab vs other tab tab). This seems to be somewhere in the javascript for the tinymce setup, where the height setting passed in is not affecting the actual size of the displayed box. Since the box enlarges as content is added to it, this is a minor issue, but if it needs to be fixed, someone with more JS knowledge than mine will need to investigate it. 

![screen shot 2017-01-24 at 11 14 50 am](https://cloud.githubusercontent.com/assets/17851674/22256953/4f47dc60-e22a-11e6-9873-1b308ef7f99c.png)

![screen shot 2017-01-24 at 11 14 36 am](https://cloud.githubusercontent.com/assets/17851674/22256956/52886818-e22a-11e6-8de0-6f015d5a05bc.png)
