### PR TITLE
Switch from scss-lint to scss_lint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring', '~> 1.7'
 
-  gem 'scss-lint'
+  gem 'scss_lint'
 end
 
 gem 'blacklight', '~> 6.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -658,9 +658,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss-lint (0.38.0)
-      rainbow (~> 2.0)
-      sass (~> 3.4.1)
+    scss_lint (0.52.0)
+      rake (>= 0.9, < 13)
+      sass (~> 3.4.20)
     secure_headers (3.6.0)
       useragent
     select2-rails (3.5.10)
@@ -810,7 +810,7 @@ DEPENDENCIES
   rubocop (~> 0.47.0)
   rubocop-rspec (~> 1.10.0)
   sass-rails (~> 5.0)
-  scss-lint
+  scss_lint
   secure_headers
   sidekiq
   simplecov
@@ -823,4 +823,4 @@ DEPENDENCIES
   zk
 
 BUNDLED WITH
-   1.13.7
+   1.14.3


### PR DESCRIPTION
Previously running bundle install showed this warning:
```
WARNING: `scss-lint` has been renamed to `scss_lint` to follow proper
RubyGems naming conventions. Update your Gemfile or relevant install
scripts to install `scss_lint`.
```