### PR TITLE
Trivial comment fix

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2,7 +2,7 @@ class CatalogController < ApplicationController
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
 
-  # These before_filters apply the hydra access controls
+  # These before_action filters apply the hydra access controls
   before_action :enforce_show_permissions, only: :show
 
   def self.uploaded_field


### PR DESCRIPTION
`before_filter` is deprecated.  The code was fixed already, but the comment wasn't.