### PR TITLE
Separate RemoveSolrCollectionJob from CleanupAccountJob

### DIFF
--- a/app/jobs/cleanup_account_job.rb
+++ b/app/jobs/cleanup_account_job.rb
@@ -1,19 +1,25 @@
 class CleanupAccountJob < ActiveJob::Base
   def perform(account)
-    account.switch do
-      solr_client.get '/solr/admin/collections', params: { action: 'DELETE', name: account.solr_endpoint.collection }
-      fcrepo_client.delete(account.fcrepo_endpoint.base_path)
-    end
-
+    cleanup_solr(account)
+    cleanup_fedora(account)
     Apartment::Tenant.drop(account.tenant)
-
     account.destroy
   end
 
   private
 
-    def solr_client
-      Blacklight.default_index.connection
+    def cleanup_fedora(account)
+      account.switch do
+        fcrepo_client.delete(account.fcrepo_endpoint.base_path)
+      end
+    end
+
+    def cleanup_solr(account)
+      # A partially set up account, may never have been given a solr_endpoint.
+      return unless account.solr_endpoint
+      # Spin off as a job, so that it can fail and be retried separately from the other logic.
+      RemoveSolrCollectionJob.perform_later(account.solr_endpoint.collection, account.solr_endpoint.connection_options)
+      account.solr_endpoint.destroy
     end
 
     def fcrepo_client

--- a/app/jobs/remove_solr_collection_job.rb
+++ b/app/jobs/remove_solr_collection_job.rb
@@ -1,0 +1,15 @@
+class RemoveSolrCollectionJob < ActiveJob::Base
+  # @param collection [String] the name of the collection
+  # @param connection_options [Hash] options for connecting to solr.
+  # @option connection_options [String] :url
+  # @option connection_options [String] :url
+  def perform(collection, connection_options)
+    solr_client(connection_options).get '/solr/admin/collections', params: { action: 'DELETE', name: collection }
+  end
+
+  private
+
+    def solr_client(connection_options)
+      RSolr.connect(connection_options)
+    end
+end

--- a/spec/jobs/cleanup_account_job_spec.rb
+++ b/spec/jobs/cleanup_account_job_spec.rb
@@ -12,14 +12,13 @@ RSpec.describe CleanupAccountJob do
       block.call
     end
 
-    allow(Blacklight.default_index.connection).to receive(:get)
+    allow(RemoveSolrCollectionJob).to receive(:perform_later)
     allow(ActiveFedora.fedora.connection).to receive(:delete)
     allow(Apartment::Tenant).to receive(:drop).with(account.tenant)
   end
 
   it 'destroys the solr collection' do
-    expect(Blacklight.default_index.connection).to receive(:get).with('/solr/admin/collections',
-                                                                      params: { action: 'DELETE', name: 'x' })
+    expect(RemoveSolrCollectionJob).to receive(:perform_later).with('x', hash_including('url'))
     described_class.perform_now(account)
   end
 

--- a/spec/jobs/remove_solr_collection_job_spec.rb
+++ b/spec/jobs/remove_solr_collection_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe RemoveSolrCollectionJob do
+  let(:collection) { 'x' }
+  let(:connection_options) { double }
+  let(:connection) { double }
+
+  it 'destroys the solr collection' do
+    expect(RSolr).to receive(:connect).with(connection_options).and_return(connection)
+    expect(connection).to receive(:get).with('/solr/admin/collections',
+                                             params: { action: 'DELETE', name: 'x' })
+    described_class.perform_now(collection, connection_options)
+  end
+end


### PR DESCRIPTION
This improves the idempotency of CleanupAccountJob

Fixes #711
