### PR TITLE
Bumps nginx timeouts to 10m

### DIFF
--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -1,11 +1,15 @@
 # From http://stackoverflow.com/a/18951706
 files:
-    "/etc/nginx/conf.d/upload.conf" :
+    "/etc/nginx/conf.d/custom.conf" :
         mode: "000755"
         owner: root
         group: root
         content: |
-           client_max_body_size 2G;
+           client_max_body_size   2G;
+           proxy_connect_timeout 600;
+           proxy_send_timeout    600;
+           proxy_read_timeout    600;
+           send_timeout          600;
     "/opt/elasticbeanstalk/hooks/appdeploy/post/50_restart_nginx.sh":
         mode: "000755"
         owner: root


### PR DESCRIPTION
Jobs that run longer than 75-90s time out on nginx as a stale connection. This commit bumps the timeout ceiling to 10 minutes for long running jobs. 

@projecthydra-labs/hyrax-code-reviewers
