### PR TITLE
Rename Roles and Permissions admin menu item

### DIFF
--- a/app/presenters/hyku/menu_presenter.rb
+++ b/app/presenters/hyku/menu_presenter.rb
@@ -29,7 +29,7 @@ module Hyku
       # we're using a case here because we need to differentiate UsersControllers
       # in different namespaces (Hyrax & Admin)
       case controller
-      when ::Admin::UsersController, RolesController
+      when ::Admin::UsersController, ::Admin::GroupsController
         true
       else
         false

--- a/app/views/hyrax/admin/_sidebar.html.erb
+++ b/app/views/hyrax/admin/_sidebar.html.erb
@@ -80,7 +80,7 @@
       </ul>
     </li>
 
-    <% if can?(:manage, Role) || can?(:manage, User) || can?(:manage, Hyku::Group) %>
+    <% if can?(:manage, User) || can?(:manage, Hyku::Group) %>
     <li>
       <a role="button" class="collapsed collapse-toggle" data-toggle="collapse" href="#collapseRoles" aria-expanded="false" aria-controls="collapseRoles">
         <span class="fa fa-users"></span>
@@ -88,11 +88,6 @@
       </a>
       <% roles_and_perms_class = 'collapse ' unless menu.roles_and_permissions_section? %>
       <ul class="<%= roles_and_perms_class %>nav nav-pills nav-stacked" id="collapseRoles">
-        <% if can? :manage, Role %>
-          <%= menu.nav_link(main_app.site_roles_path) do %>
-            <span class="fa fa-gavel"></span> <%= t('hyrax.admin.sidebar.manage_roles_and_permissions') %>
-          <% end %>
-        <% end %>
 
         <% if can? :manage, Hyku::Group %>
           <%= menu.nav_link(main_app.admin_groups_path) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,7 +116,7 @@ en:
         appearance:            'Appearance'
         content_blocks:        'Content Blocks'
         technical:             'Technical'
-        roles_and_permissions: 'Roles and permissions'
+        roles_and_permissions: 'Users and groups'
         manage_roles_and_permissions: 'Define roles and permissions'
         manage_groups: 'Manage groups'
         manage_users: 'Manage users'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -95,7 +95,7 @@ es:
         appearance:            'Apariencia'
         content_blocks:        'Bloques de contenido'
         technical:             'Técnico'
-        roles_and_permissions: 'Roles y permisos'
+        roles_and_permissions: 'Usarios y grupos'
         manage_roles_and_permissions: 'Defina roles y permisos'
         manage_groups: 'Administrar grupos'
         manage_users: 'Administrar usuarios'

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Admin Dashboard' do
         expect(page).to have_link('Content Blocks')
         expect(page).to have_link('Technical')
         expect(page).to have_link('Administrative Sets')
-        expect(page).to have_link('Define roles and permissions')
+        expect(page).to have_link('Manage groups')
         expect(page).to have_link('Manage users')
         expect(page).to have_link('Reports')
       end


### PR DESCRIPTION
Resolves issue https://github.com/projecthydra-labs/hyku/issues/483 by renaming "Roles and Permissions" to "Users and groups" and removing the menu link to manage roles and permissions. 

@projecthydra-labs/hyrax-code-reviewers
