### PR TITLE
Separate the metadata fetching from the work creation

### DIFF
--- a/app/jobs/import_work_from_purl_job.rb
+++ b/app/jobs/import_work_from_purl_job.rb
@@ -26,7 +26,7 @@ class ImportWorkFromPurlJob < ActiveJob::Base
     attributes = process_attributes(parser.attributes)
     model = model_to_create(attributes)
 
-    CreateWorkJob.perform_now(user, model, attributes, log)
+    CreateWorkJob.perform_later(user, model, attributes, log)
   end
 
   private

--- a/spec/jobs/import_work_from_purl_job_spec.rb
+++ b/spec/jobs/import_work_from_purl_job_spec.rb
@@ -14,11 +14,8 @@ RSpec.describe ImportWorkFromPurlJob do
     Hyrax::PermissionTemplate.create!(admin_set_id: Hyrax::DefaultAdminSetActor::DEFAULT_ID, workflow_name: 'default')
   end
   it "works" do
-    expect(ImportUrlJob).to receive(:perform_later).twice
-    expect do
-      described_class.perform_now(user, druid, log)
-    end.to change { GenericWork.count }.by(1)
-      .and change { FileSet.count }.by(2)
+    expect(CreateWorkJob).to receive(:perform_later)
+    described_class.perform_now(user, druid, log)
   end
 
   let(:purl_xml) do


### PR DESCRIPTION
This means we don't have to retreive metadata subsequently if there is
an error during work creating.
