### PR TITLE
Affix footer to bottom of the screen

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="navbar navbar-inverse">
+<footer class="navbar navbar-inverse site-footer">
   <div class="container-fluid">
     <div class="navbar-text text-left">
         <p><%= t('hyrax.footer.service_html') %></p>


### PR DESCRIPTION
This work was done in Sufia in January (https://github.com/projecthydra/sufia/pull/3010) but we override the footer partial, so we did not pick up changes. Adding the new `site-footer` class to our override fixes this.

