### PR TITLE
Group management javascript should use Blacklight.onLoad

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,9 +51,9 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'poltergeist'
   gem 'database_cleaner'
   gem 'factory_girl_rails'
+  gem 'poltergeist'
   gem 'rails-controller-testing'
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'poltergeist'
+  gem 'database_cleaner'
   gem 'factory_girl_rails'
   gem 'rails-controller-testing'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
     clipboard-rails (1.6.0)
+    cliver (0.3.2)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -221,6 +222,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     daemons (1.2.4)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     declarative (0.0.9)
     declarative-option (0.1.0)
@@ -526,6 +528,10 @@ GEM
       peek
       sidekiq
     pg (0.19.0)
+    poltergeist (1.13.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.1)
@@ -779,6 +785,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   config (~> 1.2, >= 1.2.1)
   coveralls
+  database_cleaner
   devise
   devise-guests (~> 0.3)
   devise-i18n
@@ -802,6 +809,7 @@ DEPENDENCIES
   peek-redis
   peek-sidekiq
   pg
+  poltergeist
   puma
   rails (= 5.0.1)
   rails-controller-testing

--- a/app/assets/javascripts/hyku/groups/add_member.js
+++ b/app/assets/javascripts/hyku/groups/add_member.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load', function() {
+Blacklight.onLoad(function() {
   $('.js-group-user-search__submit, .js-group-user-add').hide();
   $('.js-group-user-search').on('submit', function(e){ e.preventDefault(); });
 

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -1,6 +1,7 @@
-RSpec.describe 'Admin Dashboard' do
+RSpec.describe 'Admin Dashboard', type: :feature do
   context 'as an administrator' do
     let(:user) { FactoryGirl.create(:admin) }
+    let(:group) { FactoryGirl.create(:group) }
 
     before do
       login_as(user, scope: :user)
@@ -30,6 +31,12 @@ RSpec.describe 'Admin Dashboard' do
       expect(page).to have_content('Solr OK')
       expect(page).to have_content('Redis OK')
       expect(page).to have_content('Database OK')
+    end
+
+    it 'displays the add-users-to-groups page without the hidden form field', js: true do
+      visit admin_group_users_path(group)
+      expect(page).to have_content('Add User to Group')
+      expect(page).to have_selector('.js-group-user-add', visible: false)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,8 +17,10 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rails'
-
+require 'capybara/poltergeist'
+require 'database_cleaner'
 require 'active_fedora/cleaner'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -50,6 +52,10 @@ Hyrax::Admin
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+# Uses faster rack_test driver when JavaScript support not needed
+Capybara.default_driver = :rack_test
+Capybara.javascript_driver = :poltergeist
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -57,7 +63,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -83,8 +89,29 @@ RSpec.configure do |config|
   config.include Fixtures::FixtureFileUpload
   config.include FactoryGirl::Syntax::Methods
   config.include ApplicationHelper, type: :view
+  config.include Warden::Test::Helpers, type: :feature
 
-  config.before :each do |example|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do |example|
     ActiveFedora::Cleaner.clean! if example.metadata[:clean]
+    if example.metadata[:type] == :feature && Capybara.current_driver != :rack_test
+      DatabaseCleaner.strategy = :truncation
+    else
+      DatabaseCleaner.strategy = :transaction
+      DatabaseCleaner.start
+    end
+  end
+
+  config.after(:each, type: :feature) do
+    Warden.test_reset!
+    Capybara.reset_sessions!
+    page.driver.reset!
+  end
+
+  config.after do
+    DatabaseCleaner.clean
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,22 @@ ActiveRecord::Migration.maintain_test_schema!
 Capybara.default_driver = :rack_test
 Capybara.javascript_driver = :poltergeist
 
+# Adding the below to deal with random Capybara-related timeouts in CI.
+# Found in this thread: https://github.com/teampoltergeist/poltergeist/issues/375
+poltergeist_options = {
+  js_errors: false,
+  timeout: 30,
+  logger: nil,
+  phantomjs_logger: StringIO.new,
+  phantomjs_options: [
+    '--load-images=no',
+    '--ignore-ssl-errors=yes'
+  ]
+}
+Capybara.register_driver(:poltergeist) do |app|
+  Capybara::Poltergeist::Driver.new(app, poltergeist_options)
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
This effectively hides the supposed-to-be-hidden form field that the username lookup field uses behind the scenes. In order to test this, I pulled in `poltergeist` and `database_cleaner`, since this relies on javascript firing.

Fixes #837

@projecthydra-labs/hyrax-code-reviewers
