### PR TITLE
Fix logz.io cert location

### DIFF
--- a/.ebextensions/logzio.config
+++ b/.ebextensions/logzio.config
@@ -102,7 +102,7 @@ files:
               environment: ${STACK_NAME}
             fields_under_root: true
             document_type: production
-              
+
         registry_file: /var/lib/filebeat/registry
 
       output:
@@ -118,10 +118,10 @@ commands:
     command: "mkdir -p /etc/pki/tls/certs"
     cwd: /home/ec2-user
   3_download_cert:
-    command: "wget https://raw.githubusercontent.com/cloudflare/cfssl_trust/master/intermediate_ca/COMODORSADomainValidationSecureServerCA.crt"
+    command: "wget https://raw.githubusercontent.com/cloudflare/cfssl_trust/master/certdata/intermediate_ca/COMODORSADomainValidationSecureServerCA.crt"
     cwd: /etc/pki/tls/certs
   4_install_filebeat:
-    command: "yum -y install filebeat"    
+    command: "yum -y install filebeat"
   5_disable_sysv:
     command: chkconfig --del filebeat
 


### PR DESCRIPTION
Fixes current busted deploys.

The cloudflare folks moved the location of their certs to a subdir. This adjusts to that change.

@projecthydra-labs/hyrax-code-reviewers
