### PR TITLE
Create a default admin set when a tenant is created

### DIFF
--- a/app/jobs/create_default_admin_set_job.rb
+++ b/app/jobs/create_default_admin_set_job.rb
@@ -1,0 +1,5 @@
+class CreateDefaultAdminSetJob < ActiveJob::Base
+  def perform
+    AdminSet.find_or_create_default_admin_set_id
+  end
+end

--- a/spec/jobs/create_default_admin_set_job_spec.rb
+++ b/spec/jobs/create_default_admin_set_job_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe CreateDefaultAdminSetJob do
+  describe '#perform' do
+    it 'creates a new admin set for an account' do
+      expect(AdminSet).to receive(:find_or_create_default_admin_set_id).once
+      described_class.perform_now
+    end
+  end
+end


### PR DESCRIPTION
After a long discussion with @atz, @cbeer, and @jcoyne, I have decided to start by adding a new job to create a default Admin Set. A follow-up PR might be to sacrifice idempotency to handle account creation in a single job. This would be temporary, to ensure that default AS creation works during the community beta testing period (May 15th through June). Ultimately we should pursue the "UX step" approach outlined by @atz in #884, though we likely don't have time to complete and test that for a month or two.