### PR TITLE
Reduce height of topbar when viewport is desktop size

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -1,4 +1,16 @@
 #masthead {
+  @media (min-width: $screen-sm-min) {
+    &.navbar {
+      min-height: 35px;
+    }
+
+    .navbar-nav > li > a,
+    .navbar-brand {
+      height: 35px;
+      padding-top: 7.5px;
+    }
+  }
+
   #logo {
     margin-left: 10px;
   }
@@ -11,6 +23,7 @@
     display: none;
   }
 }
+
 
 .jumbotron {
   background: image_url('white-cloud-background.jpg') repeat-x;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -9,5 +9,3 @@ $jumbotron-button-background-color: #7ab55c;
 
 $features-section-background-color: #f4f4f4;
 $features-section-border-color: #ddd;
-
-$navbar-height: 35px;


### PR DESCRIPTION
Our previous strategy for reducing the height of the topbar/brandbar adversely affected the main menu navigation bar. This PR scopes changes to the topbar and to desktop viewports, so the height is unaffected on mobile where the taller topbar is helpful for containing the taller expand menu icon.

### Desktop
![after](https://cloud.githubusercontent.com/assets/101482/24681102/8e536ab4-1948-11e7-8782-519153cc8639.png)

### Mobile

![hyku](https://cloud.githubusercontent.com/assets/101482/24681162/d70291ea-1948-11e7-9ba0-7bdf35bbb498.png)

 