### PR TITLE
Temporarily turn off the rescuing of not found exceptions

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,11 @@ module Hyku
     config.action_dispatch.rescue_responses.merge!(
       "I18n::InvalidLocale" => :not_found
     )
+
+    # Temporarily remove the rescue for RecordNotFound
+    # so that we can debug https://github.com/projecthydra-labs/hyrax/issues/753
+    config.action_dispatch.rescue_responses.delete("ActiveRecord::RecordNotFound")
+    config.action_dispatch.rescue_responses.delete("ActiveFedora::ObjectNotFoundError")
+
   end
 end


### PR DESCRIPTION
So that we can figure out why non-admins can't submit works.
Ref https://github.com/projecthydra-labs/hyrax/issues/753
