### PR TITLE
Fix extra space below top bar

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -1,16 +1,4 @@
 #masthead {
-  @media (min-width: $screen-sm-min) {
-    &.navbar {
-      min-height: 35px;
-    }
-
-    .navbar-nav > li > a,
-    .navbar-brand {
-      height: 35px;
-      padding-top: 7.5px;
-    }
-  }
-
   #logo {
     margin-left: 10px;
   }
@@ -23,7 +11,6 @@
     display: none;
   }
 }
-
 
 .jumbotron {
   background: image_url('white-cloud-background.jpg') repeat-x;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -9,3 +9,5 @@ $jumbotron-button-background-color: #7ab55c;
 
 $features-section-background-color: #f4f4f4;
 $features-section-border-color: #ddd;
+
+$navbar-height: 35px;


### PR DESCRIPTION
Fixes earlier PR that inadvertently resulted in 15px of space below the top bar. Also, removes related CSS no longer needed with recent sidebar updates.

### Before
![show_dashboard____hyku 2](https://cloud.githubusercontent.com/assets/101482/24932822/29d2d248-1ec8-11e7-8efb-dd9140bb5577.png)

### After
![show_dashboard____hyku](https://cloud.githubusercontent.com/assets/101482/24932832/2f11b74c-1ec8-11e7-8655-9f0b5d90e013.png)
