### PR TITLE
Use a known-good version of tinymce-rails-imageupload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,11 @@ gem 'peek-redis'
 gem 'flipflop', '~> 2.3'
 gem 'lograge'
 
+# Pinned up tight until these are resolved:
+# https://github.com/PerfectlyNormal/tinymce-rails-imageupload/issues/86
+# https://github.com/PerfectlyNormal/tinymce-rails-imageupload/issues/87
+gem 'tinymce-rails-imageupload', '4.0.17.beta'
+
 gem 'zk'
 
 gem 'mods', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -830,6 +830,7 @@ DEPENDENCIES
   simplecov
   solr_wrapper (~> 0.10)
   spring (~> 1.7)
+  tinymce-rails-imageupload (= 4.0.17.beta)
   turbolinks
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)


### PR DESCRIPTION
https://github.com/PerfectlyNormal/tinymce-rails-imageupload/issues/86

Fixes #955