### PR TITLE
Create superadmin:grant rake task.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,8 @@ Rails:
   Enabled: true
 
 Rails/DynamicFindBy:
+  Whitelist:
+    - find_by_user_key
   Exclude:
     - 'lib/importer/factory/object_factory.rb'
 
@@ -72,6 +74,7 @@ RSpec/DescribeClass:
     - 'spec/features/**/*'
     - 'spec/views/**/*'
     - 'spec/routing/**/*'
+    - 'spec/tasks/**/*'
 
 Rails/FilePath:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,6 +17,7 @@ Style/SafeNavigation:
 Metrics/MethodLength:
   Exclude:
     - 'app/jobs/import_work_from_purl_job.rb'
+    - 'spec/support/rake.rb'
 
 RSpec/SubjectStub:
   Exclude:

--- a/lib/tasks/grant_superadmin.rake
+++ b/lib/tasks/grant_superadmin.rake
@@ -1,0 +1,14 @@
+namespace :superadmin do
+  desc 'Grant the superadmin role to specified users'
+  task 'grant', [:user_list] => [:environment] do |_cmd, args|
+    raise ArgumentError, 'A list of users is required: `rake superadmin:grant[user1,user2,...]`' unless args.user_list
+    args.to_a.each do |u|
+      user = User.find_by_user_key(u)
+      if user
+        user.add_role(:superadmin)
+      else
+        warn("Could not find user #{u}")
+      end
+    end
+  end
+end

--- a/spec/support/rake.rb
+++ b/spec/support/rake.rb
@@ -1,0 +1,41 @@
+require 'rake'
+
+module RakeHelper
+  def load_rake_environment(files)
+    @rake = Rake::Application.new
+    Rake.application = @rake
+    Rake::Task.define_task(:environment)
+    files.each { |file| load file }
+  end
+
+  def run_task(task, *args)
+    capture_stdout_stderr do
+      @rake[task].invoke(*args)
+    end
+  end
+
+  # saves original $stdout in variable
+  # set $stdout as local instance of StringIO
+  # yields to code execution
+  # returns the local instance of StringIO
+  # resets $stdout to original value
+  def capture_stdout_stderr
+    out = StringIO.new
+    err = StringIO.new
+    $stdout = out
+    $stderr = err
+    begin
+      yield
+    rescue SystemExit => e
+      puts "error = #{e.inspect}"
+    end
+    return "Output: #{out.string}\n Errors:#{err.string}"
+  ensure
+    $stdout = STDOUT
+    $stdout = STDERR
+  end
+
+  RSpec.configure do |config|
+    config.include RakeHelper
+  end
+end

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -1,0 +1,34 @@
+require 'rake'
+
+RSpec.describe "Rake tasks" do
+  describe "superadmin:grant" do
+    let!(:user1) { FactoryGirl.create(:user) }
+    let!(:user2) { FactoryGirl.create(:user) }
+
+    before do
+      load_rake_environment [File.expand_path("../../../lib/tasks/grant_superadmin.rake", __FILE__)]
+      user1.remove_role :superadmin
+      user2.remove_role :superadmin
+    end
+
+    it 'requires user_list argument' do
+      expect { run_task('superadmin:grant') }.to raise_error(ArgumentError)
+    end
+
+    it 'warns when a user is not found' do
+      expect(run_task('superadmin:grant', 'missing@example.org')).to include 'Could not find user'
+    end
+
+    it 'grants a single user the superadmin role' do
+      run_task('superadmin:grant', user1.email)
+      expect(user1.has_role?(:superadmin)).to eq true
+      expect(user2.has_role?(:superadmin)).to eq false
+    end
+
+    it 'grants a multiple users the superadmin role' do
+      run_task('superadmin:grant', user1.email, user2.email)
+      expect(user1.has_role?(:superadmin)).to eq true
+      expect(user2.has_role?(:superadmin)).to eq true
+    end
+  end
+end


### PR DESCRIPTION
Create superadmin:grant rake task.

Fixes #733

`rake superadmin:grant[user1@example.org]`
A rake task to grant the superadmin role to the specified users. 
'spec/support/rake.rb' is adapted from hyrax with added support for multiple task arguments.
find_by_user_key is whitelisted because it is actually a defined method of User..

@projecthydra-labs/hyrax-code-reviewers
