### PR TITLE
Job chaining

### DIFF
--- a/app/jobs/create_account_fcrepo_job.rb
+++ b/app/jobs/create_account_fcrepo_job.rb
@@ -1,0 +1,6 @@
+# This job is the same as its parent, but chains to the next step
+class CreateAccountFcrepoJob < CreateFcrepoEndpointJob
+  after_perform do |job|
+    CreateDefaultAdminSetJob.perform_later(job.arguments.first)
+  end
+end

--- a/app/jobs/create_default_admin_set_job.rb
+++ b/app/jobs/create_default_admin_set_job.rb
@@ -1,0 +1,6 @@
+class CreateDefaultAdminSetJob < ActiveJob::Base
+  def perform(account)
+    AccountElevator.switch!(account.tenant)
+    AdminSet.find_or_create_default_admin_set_id
+  end
+end

--- a/spec/jobs/create_account_fcrepo_job_spec.rb
+++ b/spec/jobs/create_account_fcrepo_job_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe CreateAccountFcrepoJob do
+  let(:account) { FactoryGirl.create(:account) }
+
+  it 'lets parent class handle the work' do
+    expect(CreateFcrepoEndpointJob).to receive(:perform_now).with(account)
+    described_class.perform_now(account)
+  end
+  it 'chains to next job' do
+    expect(CreateDefaultAdminSetJob).to receive(:perform_later).with(account) do |acct|
+      expect(acct.fcrepo_endpoint.base_path).to eq "/#{account.tenant}"
+    end
+    described_class.perform_now(account)
+  end
+end

--- a/spec/jobs/create_default_admin_set_job_spec.rb
+++ b/spec/jobs/create_default_admin_set_job_spec.rb
@@ -1,0 +1,15 @@
+
+RSpec.describe CreateDefaultAdminSetJob do
+  let(:account) { FactoryGirl.create(:account) }
+
+  before do
+    allow(AccountElevator).to receive(:switch!)
+  end
+
+  describe '#perform' do
+    it 'creates a new admin set for an account' do
+      expect(AdminSet).to receive(:find_or_create_default_admin_set_id).once
+      described_class.perform_now(account)
+    end
+  end
+end


### PR DESCRIPTION
For discussion.

Built on top of the existing job.  So you could reasonably compose different chains that used the same jobs in different sequences.

The main problem is that the two most costly jobs that benefit the most from parallelization are solr and fedora creation, but those are the two that we need to have logic about them both being complete.  So we either:
- sacrifice parallelism between solr and fedora creation to ensure logic
- allow the downstream job (e.g. AdminSet creation) to "spin" waiting for
  preconditions to arrive
- use a UX step/page with status polling that accomplishes the same thing

Spinning (check, sleep, check, sleep... eventually timeout) is anti-pattern for queue mgmt.