### PR TITLE
Ugly workaround to get the AttachFilesToWorkJob working again on AWS

### DIFF
--- a/config/initializers/attach_files_monkeypatch.rb
+++ b/config/initializers/attach_files_monkeypatch.rb
@@ -1,0 +1,17 @@
+# Monkey-patch around outdated Hyrax knowledge, assuming CarrierWave::Storage::Fog is present
+class AttachFilesToWorkJob
+  private
+
+    # @param [Hyrax::Actors::FileSetActor] actor
+    # @param [UploadedFileUploader] file
+    def attach_content(actor, file)
+      case file.file
+      when CarrierWave::SanitizedFile
+        actor.create_content(file.file.to_file)
+      when CarrierWave::Storage::AWSFile # only this line is different from upstream
+        import_url(actor, file)
+      else
+        raise ArgumentError, "Unknown type of file #{file.class}"
+      end
+    end
+end


### PR DESCRIPTION
Pushing this through for a workshop being held tomorrow, so they can upload files.
