### PR TITLE
Apply page header css to groups admin pages.

### DIFF
--- a/app/views/admin/groups/edit.html.erb
+++ b/app/views/admin/groups/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, construct_page_title(t('hyku.admin.groups.title.edit'), t('hyku.admin.title')) %>
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1>
     <span class="fa fa-users"></span>
     <%= t('hyku.admin.groups.title.edit') %>

--- a/app/views/admin/groups/edit.html.erb
+++ b/app/views/admin/groups/edit.html.erb
@@ -1,7 +1,9 @@
 <% content_for :page_title, construct_page_title(t('hyku.admin.groups.title.edit'), t('hyku.admin.title')) %>
-<h1>
-  <span class="fa fa-users"></span>
-  <%= t('hyku.admin.groups.title.edit') %>
-</h1>
+<% content_for :page_header do %>
+  <h1>
+    <span class="fa fa-users"></span>
+    <%= t('hyku.admin.groups.title.edit') %>
+  </h1>
+<% end %>
 <%= render 'nav' %>
 <%= render 'form' %>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -1,8 +1,10 @@
 <% content_for :page_title, construct_page_title(t('hyku.admin.groups.title.index'), t('hyku.admin.title')) %>
-<h1>
-  <span class="fa fa-users"></span>
-  <%= t('hyku.admin.groups.title.index') %>
-</h1>
+<% content_for :page_header do %>
+  <h1>
+    <span class="fa fa-users"></span>
+    <%= t('hyku.admin.groups.title.index') %>
+  </h1>
+<% end %>
 
 <div class="panel panel-default group-listing">
   <div class="panel-heading">

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, construct_page_title(t('hyku.admin.groups.title.index'), t('hyku.admin.title')) %>
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1>
     <span class="fa fa-users"></span>
     <%= t('hyku.admin.groups.title.index') %>

--- a/app/views/admin/groups/new.html.erb
+++ b/app/views/admin/groups/new.html.erb
@@ -1,8 +1,10 @@
 <% content_for :page_title, construct_page_title(t('hyku.admin.groups.title.new'), t('hyku.admin.title')) %>
-<h1>
-  <span class="fa fa-users"></span>
-  <%= t('hyku.admin.groups.title.new') %>
-</h1>
+<% content_for :page_header do %>
+  <h1>
+    <span class="fa fa-users"></span>
+    <%= t('hyku.admin.groups.title.new') %>
+  </h1>
+<% end %>
 <div class="panel-tab-wrapper">
   <ul class="nav nav-tabs">
     <li role="presentation" class="active">

--- a/app/views/admin/groups/new.html.erb
+++ b/app/views/admin/groups/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, construct_page_title(t('hyku.admin.groups.title.new'), t('hyku.admin.title')) %>
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1>
     <span class="fa fa-users"></span>
     <%= t('hyku.admin.groups.title.new') %>

--- a/app/views/admin/groups/remove.html.erb
+++ b/app/views/admin/groups/remove.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, construct_page_title(t('hyku.admin.groups.title.edit'), t('hyku.admin.title')) %>
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1>
     <span class="fa fa-users"></span>
     <%= t('hyku.admin.groups.title.edit') %>

--- a/app/views/admin/groups/remove.html.erb
+++ b/app/views/admin/groups/remove.html.erb
@@ -1,8 +1,10 @@
 <% content_for :page_title, construct_page_title(t('hyku.admin.groups.title.edit'), t('hyku.admin.title')) %>
-<h1>
-  <span class="fa fa-users"></span>
-  <%= t('hyku.admin.groups.title.edit') %>
-</h1>
+<% content_for :page_header do %>
+  <h1>
+    <span class="fa fa-users"></span>
+    <%= t('hyku.admin.groups.title.edit') %>
+  </h1>
+<% end %>
 
 <%= render 'nav' %>
 <div class="panel panel-default">

--- a/app/views/admin/groups/users.html.erb
+++ b/app/views/admin/groups/users.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, construct_page_title(t('hyku.admin.groups.title.edit'), t('hyku.admin.title')) %>
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1>
     <span class="fa fa-users"></span>
     <%= t('hyku.admin.groups.title.edit') %>

--- a/app/views/admin/groups/users.html.erb
+++ b/app/views/admin/groups/users.html.erb
@@ -1,8 +1,10 @@
 <% content_for :page_title, construct_page_title(t('hyku.admin.groups.title.edit'), t('hyku.admin.title')) %>
-<h1>
-  <span class="fa fa-users"></span>
-  <%= t('hyku.admin.groups.title.edit') %>
-</h1>
+<% content_for :page_header do %>
+  <h1>
+    <span class="fa fa-users"></span>
+    <%= t('hyku.admin.groups.title.edit') %>
+  </h1>
+<% end %>
 
 <%= render '/admin/groups/nav' %>
 <div class="panel panel-default group-user-listing">


### PR DESCRIPTION
Fixes #946 

Apply page header css to groups admin pages.

Uses content_for to add surrounding divs to the page header so they match the style of other admin pages.

@projecthydra-labs/hyrax-code-reviewers
