### PR TITLE
Inline account creation to ensure default Admin Set exists

### DIFF
--- a/app/jobs/create_account_inline_job.rb
+++ b/app/jobs/create_account_inline_job.rb
@@ -1,0 +1,8 @@
+class CreateAccountInlineJob < ActiveJob::Base
+  def perform(account)
+    CreateSolrCollectionJob.perform_now(account)
+    CreateFcrepoEndpointJob.perform_now(account)
+    CreateRedisNamespaceJob.perform_now(account)
+    CreateDefaultAdminSetJob.perform_now
+  end
+end

--- a/app/services/create_account.rb
+++ b/app/services/create_account.rb
@@ -15,9 +15,11 @@ class CreateAccount
 
   def create_external_resources
     create_tenant &&
-      create_solr_collection &&
-      create_fcrepo_endpoint &&
-      create_redis_namespace
+      create_account_inline
+    # Temporarily disabled to allow synchronous account creation
+    #   create_solr_collection &&
+    #   create_fcrepo_endpoint &&
+    #   create_redis_namespace
   end
 
   ##
@@ -27,6 +29,17 @@ class CreateAccount
       initialize_account_data
       Hyrax::Workflow::WorkflowImporter.load_workflows
     end
+  end
+
+  # Sacrifing idempotency of our account creation jobs here to reflect
+  # the dependency that exists between creating endpoints,
+  # specifically Solr and Fedora, and creation of the default Admin
+  # Set.
+  def create_account_inline
+    CreateSolrCollectionJob.perform_now(account)
+    CreateFcrepoEndpointJob.perform_now(account)
+    CreateRedisNamespaceJob.perform_now(account)
+    CreateDefaultAdminSetJob.perform_now
   end
 
   def create_solr_collection

--- a/app/services/create_account.rb
+++ b/app/services/create_account.rb
@@ -36,10 +36,7 @@ class CreateAccount
   # specifically Solr and Fedora, and creation of the default Admin
   # Set.
   def create_account_inline
-    CreateSolrCollectionJob.perform_now(account)
-    CreateFcrepoEndpointJob.perform_now(account)
-    CreateRedisNamespaceJob.perform_now(account)
-    CreateDefaultAdminSetJob.perform_now
+    CreateAccountInlineJob.perform_later(account)
   end
 
   def create_solr_collection

--- a/spec/jobs/create_account_inline_job_spec.rb
+++ b/spec/jobs/create_account_inline_job_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe CreateAccountInlineJob do
+  let(:account) { FactoryGirl.create(:account) }
+
+  describe '#perform' do
+    it 'calls four other jobs synchronously' do
+      expect(CreateSolrCollectionJob).to receive(:perform_now).with(account)
+      expect(CreateFcrepoEndpointJob).to receive(:perform_now).with(account)
+      expect(CreateRedisNamespaceJob).to receive(:perform_now).with(account)
+      expect(CreateDefaultAdminSetJob).to receive(:perform_now)
+      described_class.perform_now(account)
+    end
+  end
+end

--- a/spec/services/create_account_spec.rb
+++ b/spec/services/create_account_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe CreateAccount do
     end
   end
 
+  describe '#create_account_inline' do
+    it 'calls four jobs inline' do
+      expect(CreateSolrCollectionJob).to receive(:perform_now).with(account)
+      expect(CreateFcrepoEndpointJob).to receive(:perform_now).with(account)
+      expect(CreateRedisNamespaceJob).to receive(:perform_now).with(account)
+      expect(CreateDefaultAdminSetJob).to receive(:perform_now)
+      subject.create_account_inline
+    end
+  end
+
   describe '#save' do
     let(:resource1) { Account.new(name: 'example', title: 'First') }
     let(:resource2) { Account.new(name: 'example', title: 'Second') }

--- a/spec/services/create_account_spec.rb
+++ b/spec/services/create_account_spec.rb
@@ -40,11 +40,8 @@ RSpec.describe CreateAccount do
   end
 
   describe '#create_account_inline' do
-    it 'calls four jobs inline' do
-      expect(CreateSolrCollectionJob).to receive(:perform_now).with(account)
-      expect(CreateFcrepoEndpointJob).to receive(:perform_now).with(account)
-      expect(CreateRedisNamespaceJob).to receive(:perform_now).with(account)
-      expect(CreateDefaultAdminSetJob).to receive(:perform_now)
+    it 'queues a background job' do
+      expect(CreateAccountInlineJob).to receive(:perform_later).with(account)
       subject.create_account_inline
     end
   end


### PR DESCRIPTION
The strategy here is to inline the account creation, invoking our current jobs synchronously in order.

Anything else I should add to this? More condition checking, so if a job *is* run twice it "does the right thing?" Ideas, @atz @jcoyne @cbeer?
