### PR TITLE
Pass account object to AS creation job

### DIFF
--- a/app/jobs/create_account_inline_job.rb
+++ b/app/jobs/create_account_inline_job.rb
@@ -3,6 +3,6 @@ class CreateAccountInlineJob < ActiveJob::Base
     CreateSolrCollectionJob.perform_now(account)
     CreateFcrepoEndpointJob.perform_now(account)
     CreateRedisNamespaceJob.perform_now(account)
-    CreateDefaultAdminSetJob.perform_now
+    CreateDefaultAdminSetJob.perform_now(account)
   end
 end

--- a/app/jobs/create_default_admin_set_job.rb
+++ b/app/jobs/create_default_admin_set_job.rb
@@ -1,5 +1,10 @@
 class CreateDefaultAdminSetJob < ActiveJob::Base
-  def perform
+  def perform(account)
+    # Explicitly switch into account context; creation of the default
+    # AdminSet must happen in a per-tenant context (vs. global
+    # context). Job is serialized before the tenant is created, thus
+    # we can't take advantage of ActiveJobTenant here
+    AccountElevator.switch!(account.cname)
     AdminSet.find_or_create_default_admin_set_id
   end
 end

--- a/spec/jobs/create_default_admin_set_job_spec.rb
+++ b/spec/jobs/create_default_admin_set_job_spec.rb
@@ -1,8 +1,11 @@
 RSpec.describe CreateDefaultAdminSetJob do
+  let!(:account) { FactoryGirl.create(:account) }
+
   describe '#perform' do
     it 'creates a new admin set for an account' do
+      expect(AccountElevator).to receive(:switch!).with(account.cname)
       expect(AdminSet).to receive(:find_or_create_default_admin_set_id).once
-      described_class.perform_now
+      described_class.perform_now(account)
     end
   end
 end


### PR DESCRIPTION
Otherwise it is invoked outside of the tenant context.

