### PR TITLE
Use column_exists? to see if :workflow_id is present

### DIFF
--- a/db/migrate/20170320131133_tidy_up_because_of_bad_exception.hyrax.rb
+++ b/db/migrate/20170320131133_tidy_up_because_of_bad_exception.hyrax.rb
@@ -1,17 +1,14 @@
 # This migration comes from hyrax (originally 20170307142607)
 class TidyUpBecauseOfBadException < ActiveRecord::Migration
   def change
-    if Hyrax::PermissionTemplate.column_names.include?('workflow_id')
+    if column_exists?(Hyrax::PermissionTemplate.table_name, :workflow_id)
       Hyrax::PermissionTemplate.all.each do |permission_template|
         workflow_id = permission_template.workflow_id
         next unless workflow_id
         Sipity::Workflow.find(workflow_id).update(active: true)
       end
 
-      begin
-        remove_column Hyrax::PermissionTemplate.table_name, :workflow_id
-      rescue
-      end
+      remove_column Hyrax::PermissionTemplate.table_name, :workflow_id
     end
   end
 end


### PR DESCRIPTION
Using the column_names method on the Hyrax::PermissionTemplate class leads to false positives, which lead to exceptions, which were eaten by the bare `rescue`. Now it is possible to run `rails db:drop db:create db:migrate` without errors
