### PR TITLE
Referential integrity for endpoint IDs

### DIFF
--- a/db/migrate/20170427003546_add_index_to_accounts.rb
+++ b/db/migrate/20170427003546_add_index_to_accounts.rb
@@ -1,0 +1,15 @@
+class AddIndexToAccounts < ActiveRecord::Migration[5.0]
+  def change
+    # Remove first, else error like:
+    # Index name 'index_accounts_on_solr_endpoint_id' on table 'accounts' already exists
+    remove_index :accounts, :solr_endpoint_id
+    remove_index :accounts, :fcrepo_endpoint_id
+    remove_index :accounts, :redis_endpoint_id
+    add_foreign_key :accounts, :endpoints, column: :solr_endpoint_id, on_delete: :nullify
+    add_foreign_key :accounts, :endpoints, column: :fcrepo_endpoint_id, on_delete: :nullify
+    add_foreign_key :accounts, :endpoints, column: :redis_endpoint_id, on_delete: :nullify
+    add_index :accounts, :solr_endpoint_id, unique: true
+    add_index :accounts, :fcrepo_endpoint_id, unique: true
+    add_index :accounts, :redis_endpoint_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170320135902) do
+ActiveRecord::Schema.define(version: 20170427003546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,9 +26,9 @@ ActiveRecord::Schema.define(version: 20170320135902) do
     t.integer  "redis_endpoint_id"
     t.string   "title"
     t.index ["cname", "tenant"], name: "index_accounts_on_cname_and_tenant", using: :btree
-    t.index ["fcrepo_endpoint_id"], name: "index_accounts_on_fcrepo_endpoint_id", using: :btree
-    t.index ["redis_endpoint_id"], name: "index_accounts_on_redis_endpoint_id", using: :btree
-    t.index ["solr_endpoint_id"], name: "index_accounts_on_solr_endpoint_id", using: :btree
+    t.index ["fcrepo_endpoint_id"], name: "index_accounts_on_fcrepo_endpoint_id", unique: true, using: :btree
+    t.index ["redis_endpoint_id"], name: "index_accounts_on_redis_endpoint_id", unique: true, using: :btree
+    t.index ["solr_endpoint_id"], name: "index_accounts_on_solr_endpoint_id", unique: true, using: :btree
   end
 
   create_table "bookmarks", force: :cascade do |t|
@@ -587,6 +587,9 @@ ActiveRecord::Schema.define(version: 20170320135902) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id", using: :btree
   end
 
+  add_foreign_key "accounts", "endpoints", column: "fcrepo_endpoint_id", on_delete: :nullify
+  add_foreign_key "accounts", "endpoints", column: "redis_endpoint_id", on_delete: :nullify
+  add_foreign_key "accounts", "endpoints", column: "solr_endpoint_id", on_delete: :nullify
   add_foreign_key "content_blocks", "sites"
   add_foreign_key "curation_concerns_operations", "users"
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"


### PR DESCRIPTION
Only one account should be able to reference a given **[solr|fcrepo|redis]_endpiont**.  It is important to understand that Rails validations never truly provide guarantees of uniqueness in a multi-server application.  It **must** be done at the database level, since at runtime, the database is the only component used in common.  

For more background, see:
https://robots.thoughtbot.com/the-perils-of-uniqueness-validations

Hyku is fortunate, since it is already using postgres in all environments and postgres is perfectly capable of handling referential integrity.  