### PR TITLE
Fix tenant deletion by passing relative path to Fedora delete() call

### DIFF
--- a/app/jobs/cleanup_account_job.rb
+++ b/app/jobs/cleanup_account_job.rb
@@ -10,7 +10,8 @@ class CleanupAccountJob < ActiveJob::Base
 
     def cleanup_fedora(account)
       account.switch do
-        fcrepo_client.delete(account.fcrepo_endpoint.base_path)
+        # Preceding slash must be removed from base_path when calling delete()
+        fcrepo_client.delete(account.fcrepo_endpoint.base_path.sub!(%r{^\/}, ''))
       end
     end
 

--- a/spec/jobs/cleanup_account_job_spec.rb
+++ b/spec/jobs/cleanup_account_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CleanupAccountJob do
   end
 
   it 'destroys the fcrepo collection' do
-    expect(ActiveFedora.fedora.connection).to receive(:delete).with('/x')
+    expect(ActiveFedora.fedora.connection).to receive(:delete).with('x')
 
     described_class.perform_now(account)
   end


### PR DESCRIPTION
Currently, if you attempt to destroy a tenant from the SuperAdmin UI scaffolding at
http://[my.admin_host.url]/proprietor/accounts
(Note: this path is only accessible to superadmins. See https://github.com/projecthydra-labs/hyku/wiki)

You'll receive an error on [this line of code](https://github.com/projecthydra-labs/hyku/blob/master/app/jobs/cleanup_account_job.rb#L13) showing a 405 Response from Fedora.

This PR fixes the tenant deletion by passing a relative path to Fedora `delete()` (e.g. "[tenant-uuid]") instead of the `base_path` (e.g. "/[tenant-uuid]").  Because the latter starts with a slash (/), Fedora assumes it should be a root path and fails to locate the Container to delete.

After this PR is applied, you can delete tenants from the UI by doing the following:
* Login as a superadmin (See https://github.com/projecthydra-labs/hyku/wiki for how to set up multitenancy & superadmins locally)
* Create one or more tenants
* Visit `http://[my.admin_host_url]/proprietor/accounts` to see a list of all existing tenants
* Click the "Destroy" link next to one of them. You'll be prompted with a confirmation. Say "OK" and the tenant will be deleted (including its DB schema, Solr Collection, Fedora Container, etc).

(NOTE: Because we don't have multitenancy enabled in our test environment, the specs here fail to properly test whether the Fedora deletion was successful, which seems to be how this wasn't discovered earlier.)
