### PR TITLE
Ensure Redis namespace is cleaned up during tenant deletion

### DIFF
--- a/app/jobs/cleanup_account_job.rb
+++ b/app/jobs/cleanup_account_job.rb
@@ -1,7 +1,13 @@
 class CleanupAccountJob < ActiveJob::Base
   def perform(account)
+    # Solr endpoint pulls its connection info from account directly
     cleanup_solr(account)
-    cleanup_fedora(account)
+    # Ensure Fedora endpoint's connection established to this account
+    # and ensure Redis::Namespace limited to this account's namespace
+    account.switch do
+      cleanup_fedora(account)
+      cleanup_redis(account)
+    end
     Apartment::Tenant.drop(account.tenant)
     account.destroy
   end
@@ -9,10 +15,25 @@ class CleanupAccountJob < ActiveJob::Base
   private
 
     def cleanup_fedora(account)
-      account.switch do
-        # Preceding slash must be removed from base_path when calling delete()
-        fcrepo_client.delete(account.fcrepo_endpoint.base_path.sub!(%r{^\/}, ''))
-      end
+      # Return immediately if fcrepo_endpoint doesn't exist
+      return unless account.fcrepo_endpoint
+      # Preceding slash must be removed from base_path when calling delete()
+      fcrepo_client.delete(account.fcrepo_endpoint.base_path.sub!(%r{^/}, ''))
+      account.fcrepo_endpoint.destroy
+    end
+
+    def cleanup_redis(account)
+      # Return immediately if redis_endpoint doesn't exist
+      return unless account.redis_endpoint
+      # Redis::Namespace currently doesn't support flushall or flushdb.
+      # See https://github.com/resque/redis-namespace/issues/56
+      # So, instead we select all keys in current namespace and delete
+      keys = redis_namespace.keys '*'
+      return if keys.empty?
+      # Delete in slices to avoid "stack level too deep" errors for large numbers of keys
+      # See https://github.com/redis/redis-rb/issues/122
+      keys.each_slice(1000) { |key_slice| redis_namespace.del(*key_slice) }
+      account.redis_endpoint.destroy
     end
 
     def cleanup_solr(account)
@@ -25,5 +46,10 @@ class CleanupAccountJob < ActiveJob::Base
 
     def fcrepo_client
       ActiveFedora.fedora.connection
+    end
+
+    def redis_namespace
+      # This is a Redis::Namespace which is already limited to account's namespace
+      Hyrax::RedisEventStore.instance
     end
 end

--- a/spec/jobs/cleanup_account_job_spec.rb
+++ b/spec/jobs/cleanup_account_job_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe CleanupAccountJob do
   let!(:account) do
     FactoryGirl.create(:account, solr_endpoint_attributes: { collection: 'x' },
-                                 fcrepo_endpoint_attributes: { base_path: '/x' })
+                                 fcrepo_endpoint_attributes: { base_path: '/x' },
+                                 redis_endpoint_attributes: { namespace: 'x' })
   end
 
   before do
@@ -17,12 +18,25 @@ RSpec.describe CleanupAccountJob do
 
   it 'destroys the solr collection' do
     expect(RemoveSolrCollectionJob).to receive(:perform_later).with('x', hash_including('url'))
+    expect(account.solr_endpoint).to receive(:destroy)
     described_class.perform_now(account)
   end
 
   it 'destroys the fcrepo collection' do
     expect(ActiveFedora.fedora.connection).to receive(:delete).with('x')
+    expect(account.fcrepo_endpoint).to receive(:destroy)
+    described_class.perform_now(account)
+  end
 
+  it 'deletes all entries in the redis namespace' do
+    allow(Redis.current).to receive(:keys).and_return(["x:events:x1", "x:events:x2"])
+    allow(Hyrax::RedisEventStore).to receive(:instance).and_return(
+      Redis::Namespace.new(account.redis_endpoint.namespace, redis: Redis.current)
+    )
+    expect(Hyrax::RedisEventStore.instance.namespace).to eq('x')
+    expect(Hyrax::RedisEventStore.instance.keys).to eq(["events:x1", "events:x2"])
+    expect(Hyrax::RedisEventStore.instance).to receive(:del).with('events:x1', 'events:x2')
+    expect(account.redis_endpoint).to receive(:destroy)
     described_class.perform_now(account)
   end
 


### PR DESCRIPTION
Enhances `CleanupAccountJob` to also cleanup Redis namespace whenever an Account/tenant is deleted. This is a followup to comments in #1022.

The code works, but the specs currently leave something to be desired.  Just pushing this up for now and will take another look next week.
