### PR TITLE
Indent admin menu submenu items

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -101,6 +101,12 @@ footer.navbar {
   .h5 {
     padding: $nav-link-padding;
   }
+
+  &.maximized {
+    .admin-sidebar ul > li a {
+      padding-left: 52px;
+    }
+  }
 }
 
 .panel-tab-wrapper {


### PR DESCRIPTION
Fixes #982 

Indents submenu items in admin sidebar so it is more clear that they below to their parent menu item.

![index_transfer____hyku](https://cloud.githubusercontent.com/assets/101482/25674532/0050d5ee-2ff0-11e7-8540-ddbd3183d2d8.png)

--

![index_transfer____hyku 2](https://cloud.githubusercontent.com/assets/101482/25674526/fc7533fc-2fef-11e7-9438-faf0c581f290.png)