### PR TITLE
User - remove comment reference to account

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,8 +18,7 @@ class User < ActiveRecord::Base
   before_create :add_default_roles
 
   # Method added by Blacklight; Blacklight uses #to_s on your
-  # user class to get a user-displayable login/identifier for
-  # the account.
+  # user class to get a user-displayable login/identifier.
   def to_s
     email
   end


### PR DESCRIPTION
User code should not refer to `account` in this App, as this is an important distiction in this app.

@projecthydra-labs/hyrax-code-reviewers
