### PR TITLE
Segregate tenant uploads into separate subfolders

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -97,7 +97,9 @@ Hyrax.config do |config|
 
   # Temporary path to hold uploads before they are ingested into FCrepo.
   # This must be a lambda that returns a Pathname
-  #  config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' }
+  if Settings.multitenancy.enabled
+   config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' + Apartment::Tenant.current }
+  end
 
   # Location on local file system where derivatives will be stored.
   # If you use a multi-server architecture, this MUST be a shared volume.

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -98,7 +98,13 @@ Hyrax.config do |config|
   # Temporary path to hold uploads before they are ingested into FCrepo.
   # This must be a lambda that returns a Pathname
   if Settings.multitenancy.enabled
-   config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' + Apartment::Tenant.current }
+   config.upload_path = ->() do
+     if Settings.s3.upload_bucket
+       "uploads/#{Apartment::Tenant.current}"
+     else
+       Rails.root + 'tmp' + 'uploads' + Apartment::Tenant.current
+     end
+   end
   end
 
   # Location on local file system where derivatives will be stored.


### PR DESCRIPTION
Also, use a more compact tree (without an annoying leading slash) when uploading into S3.