### PR TITLE
Revert "Fix extra space below top bar"

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -1,4 +1,16 @@
 #masthead {
+  @media (min-width: $screen-sm-min) {
+    &.navbar {
+      min-height: 35px;
+    }
+
+    .navbar-nav > li > a,
+    .navbar-brand {
+      height: 35px;
+      padding-top: 7.5px;
+    }
+  }
+
   #logo {
     margin-left: 10px;
   }
@@ -11,6 +23,7 @@
     display: none;
   }
 }
+
 
 .jumbotron {
   background: image_url('white-cloud-background.jpg') repeat-x;

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -1,16 +1,4 @@
 #masthead {
-  @media (min-width: $screen-sm-min) {
-    &.navbar {
-      min-height: 35px;
-    }
-
-    .navbar-nav > li > a,
-    .navbar-brand {
-      height: 35px;
-      padding-top: 7.5px;
-    }
-  }
-
   #logo {
     margin-left: 10px;
   }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -9,5 +9,3 @@ $jumbotron-button-background-color: #7ab55c;
 
 $features-section-background-color: #f4f4f4;
 $features-section-border-color: #ddd;
-
-$navbar-height: 35px;


### PR DESCRIPTION
Fixes #1078.

@ggeisler you were trying to fix the top navbar height in #945, but the fix broke other navbar styling (see #1078). This commit reverts it, and changes the top navbar to the default 50px, so at least nothing looks broken.

How important is it that the top navbar be 35px high? Is 50px something we can live with for now, or do we need to come up with a better fix?