### PR TITLE
Remove `SETTINGS__MULTITENANCY__ENABLED` setting

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -25,7 +25,6 @@ services:
       - SETTINGS__ACTIVE_JOB__QUEUE_ADAPTER=sidekiq
       - SETTINGS__SOLR__URL=http://solr:8983/solr/
       - SETTINGS__ZOOKEEPER__CONNECTION_STR=zookeeper_cluster:2181/configs
-      - SETTINGS__MULTITENANCY__ENABLED=false
       - RAILS_ENV=production
       - RAILS_SERVE_STATIC_FILES=true
       - RAILS_LOG_TO_STDOUT=true


### PR DESCRIPTION
Not only is the docker-ified application not set up for that, it is interpreted in railsconfig-land as the string `"false"` (which is truth-y)

I suspect this was introducing unintentionally in #954.