### PR TITLE
Switch all or bust

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -77,9 +77,9 @@ class Account < ActiveRecord::Base
 
   # does not use confirm_endpoints! because we can still nil-ify settings
   def reset!
-    solr_endpoint.reset!
-    fcrepo_endpoint.reset!
-    redis_endpoint.reset!
+    SolrEndpoint.reset!
+    FcrepoEndpoint.reset!
+    RedisEndpoint.reset!
   end
 
   private

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -62,9 +62,10 @@ class Account < ActiveRecord::Base
 
   # Make all the account specific connections active
   def switch!
-    solr_endpoint.switch! if solr_endpoint
-    fcrepo_endpoint.switch! if fcrepo_endpoint
-    redis_endpoint.switch! if redis_endpoint
+    confirm_endpoints!
+    solr_endpoint.switch!
+    fcrepo_endpoint.switch!
+    redis_endpoint.switch!
   end
 
   def switch
@@ -74,13 +75,21 @@ class Account < ActiveRecord::Base
     reset!
   end
 
+  # does not use confirm_endpoints! because we can still nil-ify settings
   def reset!
-    solr_endpoint.reset! if solr_endpoint
-    fcrepo_endpoint.reset! if fcrepo_endpoint
-    redis_endpoint.reset! if redis_endpoint
+    solr_endpoint.reset!
+    fcrepo_endpoint.reset!
+    redis_endpoint.reset!
   end
 
   private
+
+    # @raise [RuntimeError] if missing any endpoint
+    def confirm_endpoints!
+      raise "Account #{cname} is missing solr_endpoint, cannot switch!" unless solr_endpoint
+      raise "Account #{cname} is missing fcrepo_endpoint, cannot switch!" unless fcrepo_endpoint
+      raise "Account #{cname} is missing redis_endpoint, cannot switch!" unless redis_endpoint
+    end
 
     def default_cname(piece = name)
       self.class.default_cname(piece)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -86,9 +86,9 @@ class Account < ActiveRecord::Base
 
     # @raise [RuntimeError] if missing any endpoint
     def confirm_endpoints!
-      raise "Account #{cname} is missing solr_endpoint, cannot switch!" unless solr_endpoint
-      raise "Account #{cname} is missing fcrepo_endpoint, cannot switch!" unless fcrepo_endpoint
-      raise "Account #{cname} is missing redis_endpoint, cannot switch!" unless redis_endpoint
+      raise MissingSolrException, "Account #{cname} is missing solr_endpoint, cannot switch!" unless solr_endpoint
+      raise MissingFcrepoException, "Account #{cname} is missing fcrepo_endpoint, cannot switch!" unless fcrepo_endpoint
+      raise MissingRedisException, "Account #{cname} is missing redis_endpoint, cannot switch!" unless redis_endpoint
     end
 
     def default_cname(piece = name)
@@ -99,3 +99,7 @@ class Account < ActiveRecord::Base
       self.cname &&= self.class.canonical_cname(cname)
     end
 end
+
+class MissingSolrException < RuntimeError; end
+class MissingFcrepoException < RuntimeError; end
+class MissingRedisException < RuntimeError; end

--- a/app/models/fcrepo_endpoint.rb
+++ b/app/models/fcrepo_endpoint.rb
@@ -5,7 +5,7 @@ class FcrepoEndpoint < Endpoint
     ActiveFedora::Fedora.register(options.symbolize_keys)
   end
 
-  def reset!
+  def self.reset!
     ActiveFedora::Fedora.reset!
   end
 

--- a/app/models/redis_endpoint.rb
+++ b/app/models/redis_endpoint.rb
@@ -6,7 +6,7 @@ class RedisEndpoint < Endpoint
   end
 
   # Reset the Redis namespace back to the default value
-  def reset!
+  def self.reset!
     Hyrax.config.redis_namespace = Settings.redis.default_namespace
   end
 

--- a/app/models/solr_endpoint.rb
+++ b/app/models/solr_endpoint.rb
@@ -27,7 +27,7 @@ class SolrEndpoint < Endpoint
     Blacklight.default_index = nil
   end
 
-  def reset!
+  def self.reset!
     ActiveFedora::SolrService.reset!
     Blacklight.connection_config = nil
     Blacklight.default_index = nil

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -98,6 +98,10 @@ RSpec.describe Account, type: :model do
       subject.switch!
     end
 
+    after do
+      subject.reset!
+    end
+
     it 'switches to the account-specific connection' do
       subject.switch do
         expect(ActiveFedora::SolrService.instance.conn.uri.to_s).to eq 'http://example.com/solr/'
@@ -111,10 +115,16 @@ RSpec.describe Account, type: :model do
       subject.switch do
         # no-op
       end
-
       expect(ActiveFedora::SolrService.instance.conn.uri.to_s).to eq 'http://127.0.0.1:8985/solr/hydra-test/'
       expect(ActiveFedora.fedora.host).to eq 'http://127.0.0.1:8986/rest'
       expect(Hyrax.config.redis_namespace).to eq previous_redis_namespace
+    end
+
+    context 'with missing endpoint' do
+      it 'throws exception on switch!' do
+        subject.solr_endpoint = nil
+        expect { subject.switch! }.to raise_error(RuntimeError)
+      end
     end
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -121,9 +121,17 @@ RSpec.describe Account, type: :model do
     end
 
     context 'with missing endpoint' do
-      it 'throws exception on switch!' do
+      it 'Solr, throws exception on switch!' do
         subject.solr_endpoint = nil
-        expect { subject.switch! }.to raise_error(RuntimeError)
+        expect { subject.switch! }.to raise_error(MissingSolrException)
+      end
+      it 'Fcrepo, throws exception on switch!' do
+        subject.fcrepo_endpoint = nil
+        expect { subject.switch! }.to raise_error(MissingFcrepoException)
+      end
+      it 'Redis, throws exception on switch!' do
+        subject.redis_endpoint = nil
+        expect { subject.switch! }.to raise_error(MissingRedisException)
       end
     end
   end


### PR DESCRIPTION
Prevents half-formed tenants from partially or entirely in the global lobby.  

Also refactors `reset!` to be at each Endpoint's descendants' class level, therefore `@account.reset!` is not dependent on account well-formedness, while `switch!` decidedly is.  