### PR TITLE
hyrax controllers are missing a breadcrumbs mixin

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -1,7 +1,6 @@
 module Hyrax
   class FileSetsController < ApplicationController
     include Hyrax::FileSetsControllerBehavior
-    include Hyrax::FileSetsControllerBehavior
     self.show_presenter = Hyku::FileSetPresenter
   end
 end

--- a/app/controllers/hyrax/generic_works_controller.rb
+++ b/app/controllers/hyrax/generic_works_controller.rb
@@ -2,6 +2,7 @@ module Hyrax
   class GenericWorksController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
 
     self.curation_concern_type = GenericWork
 

--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -2,6 +2,7 @@ module Hyrax
   class ImagesController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
 
     self.curation_concern_type = Image
 


### PR DESCRIPTION
Fixes #1096 

The issue describes the approach taken here.  Basically, it updates the hyrax controllers with a new mixin for the breadcrumbs.

NOTE:  the breadcrumbs for the `FileSetsController` is a GUESS.  I don't know, yet, whether it should be added and, if so, whether it should be a `BreadcrumbsForCollections` mixin.

@projecthydra-labs/hyrax-code-reviewers
