### PR TITLE
Consolidate set_site to SitesController and inherit downstream

### DIFF
--- a/app/controllers/content_blocks_controller.rb
+++ b/app/controllers/content_blocks_controller.rb
@@ -1,8 +1,4 @@
-class ContentBlocksController < ApplicationController
-  before_action :set_site
-  load_and_authorize_resource instance_variable: :site, class: 'Site'
-  layout 'dashboard'
-
+class ContentBlocksController < SitesController
   # GET /sites/1/edit
   def edit
     add_breadcrumb t(:'hyrax.controls.home'), root_path
@@ -23,10 +19,6 @@ class ContentBlocksController < ApplicationController
   end
 
   private
-
-    def set_site
-      @site ||= Site.instance
-    end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def site_params

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -1,8 +1,4 @@
-class LabelsController < ApplicationController
-  before_action :set_site
-  load_and_authorize_resource instance_variable: :site, class: 'Site'
-  layout 'dashboard'
-
+class LabelsController < SitesController
   # GET /sites/1/edit
   def edit
     add_breadcrumb t(:'hyrax.controls.home'), root_path
@@ -23,10 +19,6 @@ class LabelsController < ApplicationController
   end
 
   private
-
-    def set_site
-      @site ||= Site.instance
-    end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def site_params

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -6,7 +6,7 @@ class SitesController < ApplicationController
   def update
     params.require(:remove_banner_image)
     @site.remove_banner_image!
-    redirect_to hyrax.admin_appearance_path
+    redirect_to hyrax.admin_appearance_path, notice: 'The appearance was successfully updated.'
   end
 
   private

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,5 +1,17 @@
 class SitesController < ApplicationController
   before_action :set_site
-  load_and_authorize_resource
+  load_and_authorize_resource instance_variable: :site, class: 'Site' # descendents still auth Site
   layout 'dashboard'
+
+  def update
+    params.require(:remove_banner_image)
+    @site.remove_banner_image!
+    redirect_to hyrax.admin_appearance_path
+  end
+
+  private
+
+    def set_site
+      @site ||= Site.instance
+    end
 end

--- a/app/forms/appearance_form.rb
+++ b/app/forms/appearance_form.rb
@@ -1,6 +1,6 @@
 # The for for the color picker and background setter
 class AppearanceForm < Hyrax::Forms::Admin::Appearance
-  delegate :banner_image, :banner_image?, :remove_banner_image, to: :site
+  delegate :banner_image, :banner_image?, to: :site
 
   # Whitelisted parameters
   def self.permitted_params
@@ -13,7 +13,11 @@ class AppearanceForm < Hyrax::Forms::Admin::Appearance
 
   # @return [Array<Symbol>] a list of fields that are related to the banner
   def self.banner_fields
-    [:banner_image, :remove_banner_image]
+    [:banner_image]
+  end
+
+  def site
+    @site ||= Site.instance
   end
 
   private
@@ -21,9 +25,5 @@ class AppearanceForm < Hyrax::Forms::Admin::Appearance
     # @return [Hash] attributes that are related to the banner
     def banner_attributes
       attributes.slice(*self.class.banner_fields)
-    end
-
-    def site
-      @site ||= Site.instance
     end
 end

--- a/app/views/hyrax/admin/appearances/show.html.erb
+++ b/app/views/hyrax/admin/appearances/show.html.erb
@@ -19,12 +19,18 @@
             <%= simple_form_for @form, url: admin_appearance_path do |f| %>
               <div class="panel-body">
                 <%# Upload Banner Image %>
-                <%= f.input :banner_image, as: :file, wrapper: :vertical_file_input, hint: 'Upload an image (JPG, GIF or PNG) at least 2200 pixels wide for best results.'%>
+                <%= f.input :banner_image, as: :file, wrapper: :vertical_file_input, hint: 'Upload an image (JPG, GIF or PNG) at least 2200 pixels wide for best results.' %>
                 <%= image_tag @form.banner_image.url, class: "img-responsive" if @form.banner_image? %>
-                <%= f.input :remove_banner_image, as: :boolean %>
               </div>
               <div class="panel-footer">
-                <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+                <%= f.button :submit, class: 'btn-primary pull-right' %>
+              </div>
+            <% end %>
+            <% if @form.banner_image? %>
+              <div class="panel-footer">
+                <%= simple_form_for @form.site, url: main_app.site_path(@form.site) do |f| %>
+                  <%= f.button :submit, 'Remove banner image', type: :submit, class: 'btn-danger', name: :remove_banner_image %>
+                <% end %>
               </div>
             <% end %>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   get 'status', to: 'status#index'
 
   mount BrowseEverything::Engine => '/browse'
-  resource :site, only: [] do
+  resource :site, only: [:update] do
     resources :roles, only: [:index, :update]
     resource :content_blocks, only: [:edit, :update]
     resource :labels, only: [:edit, :update]

--- a/spec/controllers/hyrax/admin/appearances_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/appearances_controller_spec.rb
@@ -53,21 +53,6 @@ RSpec.describe Hyrax::Admin::AppearancesController, type: :controller, singleten
         end
       end
 
-      context "site with existing banner image" do
-        before do
-          f = fixture_file_upload('/images/nypl-hydra-of-lerna.jpg', 'image/jpg')
-          Site.instance.update(banner_image: f)
-        end
-
-        it "deletes a banner image" do
-          expect(Site.instance.banner_image?).to be true
-          post :update, params: { id: Site.instance.id, admin_appearance: { remove_banner_image: 'true' } }
-          expect(response).to redirect_to(hyrax.admin_appearance_path(locale: 'en'))
-          expect(flash[:notice]).to include("The appearance was successfully updated")
-          expect(Site.instance.banner_image?).to be false
-        end
-      end
-
       context "with invalid params" do
         let(:invalid_attributes) do
           { banner_image: "" }

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe SitesController, type: :controller, singletenant: true do
+  before { sign_in user }
+
+  context 'with an unprivileged user' do
+    let(:user) { create(:user) }
+
+    describe "POST #update" do
+      it "denies the request" do
+        post :update
+        expect(response).to have_http_status(401)
+      end
+    end
+  end
+
+  context 'with an administrator' do
+    let(:user) { create(:admin) }
+
+    context "site with existing banner image" do
+      before do
+        f = fixture_file_upload('/images/nypl-hydra-of-lerna.jpg', 'image/jpg')
+        Site.instance.update(banner_image: f)
+      end
+
+      it "deletes a banner image" do
+        expect(Site.instance.banner_image?).to be true
+        post :update, params: { id: Site.instance.id, remove_banner_image: 'Remove banner image' }
+        expect(response).to redirect_to('/admin/appearance?locale=en')
+        expect(flash[:notice]).to include("The appearance was successfully updated")
+        expect(Site.instance.banner_image?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
`SitesController` previously had a call that *required* set_site to exist in itself, but it did not have it defined.  This is required to make `SitesController` useful. At the same time, we can utilize inheritance.

Fixes #960 