### PR TITLE
Fixes to tenant deletion (cleanup_account_job.rb)

### DIFF
--- a/app/jobs/remove_solr_collection_job.rb
+++ b/app/jobs/remove_solr_collection_job.rb
@@ -10,6 +10,7 @@ class RemoveSolrCollectionJob < ActiveJob::Base
   private
 
     def solr_client(connection_options)
-      RSolr.connect(connection_options)
+      # We remove the adapter, otherwise RSolr 2 will try to use it as a Faraday middleware
+      RSolr.connect(connection_options.without('adapter'))
     end
 end

--- a/spec/jobs/cleanup_account_job_spec.rb
+++ b/spec/jobs/cleanup_account_job_spec.rb
@@ -6,12 +6,8 @@ RSpec.describe CleanupAccountJob do
   end
 
   before do
-    # stub switch so we don't need to worry about changing resource handles
-    allow(account).to receive(:switch) do |&block|
-      block.call
-    end
-
     allow(RemoveSolrCollectionJob).to receive(:perform_later)
+    allow(account.fcrepo_endpoint).to receive(:switch!)
     allow(ActiveFedora.fedora.connection).to receive(:delete)
     allow(Apartment::Tenant).to receive(:drop).with(account.tenant)
   end

--- a/spec/jobs/remove_solr_collection_job_spec.rb
+++ b/spec/jobs/remove_solr_collection_job_spec.rb
@@ -3,6 +3,11 @@ RSpec.describe RemoveSolrCollectionJob do
   let(:connection_options) { double }
   let(:connection) { double }
 
+  before do
+    # Stub connection_options to respond with itself when without('adapter') called
+    allow(connection_options).to receive(:without).with('adapter').and_return(connection_options)
+  end
+
   it 'destroys the solr collection' do
     expect(RSolr).to receive(:connect).with(connection_options).and_return(connection)
     expect(connection).to receive(:get).with('/solr/admin/collections',


### PR DESCRIPTION
Fixes following issues on `master`:

* Partial tenants (e.g. where one or more endpoints are missing) cannot be deleted (as an exception is thrown when `Account.switch` is called on a partial tenant). This is resolved by https://github.com/projecthydra-labs/hyku/pull/1140/commits/cfc07300c2e36e8ea12b8f4f8a8dfd14f2c3f609
* When a Solr endpoint is deleted, the underlying Solr Collection remains. This is resolved by https://github.com/projecthydra-labs/hyku/pull/1140/commits/d58a760178e6fb4cb31c2c6c328cfa99ddc1b7fb

@projecthydra-labs/hyrax-code-reviewers
