### PR TITLE
Add missing model tests

### DIFF
--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,7 +1,7 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe Collection do
-  it "has tests" do
-    skip "Add your tests here"
+  it "is a hyrax collection" do
+    expect(described_class.ancestors).to include Hyrax::CollectionBehavior
   end
 end

--- a/spec/models/qa/local_authority_entry_spec.rb
+++ b/spec/models/qa/local_authority_entry_spec.rb
@@ -1,5 +1,7 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe Qa::LocalAuthorityEntry, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "belongs to a local authority" do
+    expect(described_class.reflections['local_authority'].macro).to eq :belongs_to
+  end
 end

--- a/spec/models/qa/local_authority_spec.rb
+++ b/spec/models/qa/local_authority_spec.rb
@@ -1,5 +1,8 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe Qa::LocalAuthority, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "can persist data" do
+    expect { described_class.create!(name: 'Language') }
+      .to change { described_class.count }.by(1)
+  end
 end


### PR DESCRIPTION
Mostly this is just to help us avoid "pending" warnings in the test suite.